### PR TITLE
Drop the "pages with no feed are handed straight back" README bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,6 @@ Every bug found so far, and what each one looked like:
   offer them logged out either.
 - **Adult content is opt-in**, the way old Reddit did it: a placeholder tile in listings,
   and a blurred *click to view* on a post you open on purpose. Nothing loads until you ask.
-- **Pages with no feed are handed straight back.** Age gates, private communities and
-  rate-limit pages are left alone, so nothing covers the button you need.
 
 **In:** the home feed, `/r/*` listings, comment pages, user profiles, header, sort tabs, the
 `top`/`controversial` time window, sidebar.


### PR DESCRIPTION
## What this changes

README.md only. Removes one Scope bullet claiming age gates, private communities and rate-limit pages are handed straight back untouched. Age gates are skipped rather than left alone, so the line was not accurate.

## What the wrong behaviour looked like

Not a bug fix. A README claim that overstated what the extension does with gate pages.

## Testing

Not run: no file outside README.md changed.

- [ ] `npm test` passes (n/a, docs only)
- [ ] Browser suites actually ran (n/a)
- [ ] New assertions have a matching row in `test/mutate.sh` (n/a)
- [ ] `bash test/mutate.sh` anchors still match (n/a, no source edited)

## Checklist

- [x] No `shreddit-*` selector outside `src/config/contracts.js`
- [x] No hard-coded colours in `src/styles/old-reddit.css`
- [x] Unhandled routes are still completely untouched
- [x] No network requests of its own were added
- [x] Version bump: not needed, no shippable file changed
- [x] `npm run package`: not needed, nothing shippable changed
- [x] Docs updated: this is the docs change

## Anything reviewers should know

Nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbUPL1pPRJo1kehoy5Lwqi

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbUPL1pPRJo1kehoy5Lwqi)_